### PR TITLE
Leo's populate_hits_avx

### DIFF
--- a/include/fastscancount.h
+++ b/include/fastscancount.h
@@ -53,7 +53,7 @@ uint32_t *natefastscancount_finalcheck(uint8_t *counters, size_t &it,
 
 void fastscancount(const std::vector<const std::vector<uint32_t>*> &data,
                    std::vector<uint32_t> &out, uint8_t threshold) {
-  size_t cache_size = 32768;
+  size_t cache_size = 65536;
   size_t range = cache_size;
   std::vector<uint8_t> counters(cache_size);
   size_t ds = data.size();

--- a/include/fastscancount.h
+++ b/include/fastscancount.h
@@ -53,7 +53,7 @@ uint32_t *natefastscancount_finalcheck(uint8_t *counters, size_t &it,
 
 void fastscancount(const std::vector<const std::vector<uint32_t>*> &data,
                    std::vector<uint32_t> &out, uint8_t threshold) {
-  size_t cache_size = 65536;
+  size_t cache_size = 32768;
   size_t range = cache_size;
   std::vector<uint8_t> counters(cache_size);
   size_t ds = data.size();

--- a/include/fastscancount_avx2.h
+++ b/include/fastscancount_avx2.h
@@ -121,7 +121,7 @@ void update_counters_final(const uint32_t *&it_, const uint32_t *end,
 
 void fastscancount_avx2(const std::vector<const std::vector<uint32_t>*> &data,
                         std::vector<uint32_t> &out, uint8_t threshold) {
-  const size_t cache_size = 32768;
+  const size_t cache_size = 40000;
   std::vector<uint8_t> counters(cache_size);
   out.clear();
   const size_t dsize = data.size();


### PR DESCRIPTION
I took Leo's PR and reverted back the change in cache size, to isolate the effect of his new populate_hits_avx. (It is hard to reason about multiple changes at once.)

Before (master)...

Trial 1...
```
AVX2-based scancount
2.78173 cycles/element 
2.41643 instructions/cycles 
0.00283376 miss/element 
Elems per millisecond:
fastscancount_avx2: 1.26256e+06
```

Trial 2...
```
AVX2-based scancount
2.75127 cycles/element 
2.44319 instructions/cycles 
0.00283133 miss/element 
Elems per millisecond:
fastscancount_avx2: 1.26693e+06
```


After... (merging this PR)

Trial 1...
```
AVX2-based scancount
3.02782 cycles/element 
2.36966 instructions/cycles 
0.00274635 miss/element 
Elems per millisecond:
fastscancount_avx2: 1.17293e+06
```

Trial 2...
```
AVX2-based scancount
3.02123 cycles/element 
2.37482 instructions/cycles 
0.00278034 miss/element 
Elems per millisecond:
fastscancount_avx2: 1.17274e+06
```


As you can see, I observe a performance regression with this PR.