### PR TITLE
512-bit test + benchmark improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 OPT := -O3
-CXXFLAGS := -std=c++17 $(OPT) -mavx2
+# Leo really doubts -mavx2 helps anything, but one can
+# disable avx512 tests by enforcing -mavx2
+#CXXFLAGS := -std=c++17 $(OPT) -mavx2
+CXXFLAGS := -std=c++17 $(OPT) -march=native
 
 counter: benchmark/counters.cpp include/*.h Makefile
 	$(CXX) $(CXXFLAGS) $(CXXEXTRA) -o counter benchmark/counters.cpp -Ibenchmark -Iinclude

--- a/benchmark/counters.cpp
+++ b/benchmark/counters.cpp
@@ -4,6 +4,9 @@
 #ifdef __AVX2__
 #include "fastscancount_avx2.h"
 #endif
+#ifdef __AVX512F__
+#include "fastscancount_avx512.h"
+#endif
 #include "linux-perf-events-wrapper.h"
 #include "maropuparser.h"
 #include <algorithm>
@@ -12,9 +15,12 @@
 #include <immintrin.h>
 #include <iostream>
 #include <vector>
+#include <stdexcept>
 
 #define REPEATS 10
-void scancount(std::vector<const std::vector<uint32_t>*> &data,
+#define RUNNINGTESTS
+
+void scancount(const std::vector<const std::vector<uint32_t>*> &data,
                std::vector<uint32_t> &out, size_t threshold) {
   uint64_t largest = 0;
   for(auto z : data) {
@@ -32,6 +38,64 @@ void scancount(std::vector<const std::vector<uint32_t>*> &data,
   for (uint32_t i = 0; i < counters.size(); i++) {
     if (counters[i] > threshold)
       out.push_back(i);
+  }
+}
+
+void calc_boundaries(uint32_t largest, uint32_t range_size, 
+                    const std::vector<uint32_t>& data, 
+                    std::vector<uint32_t>& range_ends) {
+  if (!range_size) {
+    throw std::runtime_error("range_size must be > 0");
+  }
+  uint32_t end = 0;
+  range_ends.clear();
+  
+  for (uint32_t start = 0; start <= largest; start += range_size) {
+    uint32_t curr_max = std::min(largest, start + range_size - 1);
+    while (end < data.size() && data[end] <= curr_max) {
+      end++;
+    }
+    range_ends.push_back(end);
+  }
+} 
+
+const uint32_t range_size_avx512 = 40000;
+
+void calc_alldata_boundaries(const std::vector<std::vector<uint32_t>>& data,
+                             std::vector<std::vector<uint32_t>>& range_ends,
+                             size_t range_size) {
+  uint32_t largest = 0;
+  range_ends.clear();
+  range_ends.resize(data.size());
+  for(const auto& v : data) {
+    if (!v.empty() && v[v.size() - 1] > largest) largest = v[v.size() - 1];
+  }
+  for (unsigned i = 0; i < data.size(); ++i) {
+    calc_boundaries(largest, range_size, data[i], range_ends[i]); 
+  }
+}
+
+template <typename F>
+void test(F f, const std::vector<const std::vector<uint32_t>*>& data_ptrs,
+          std::vector<uint32_t>& answer, unsigned threshold, const std::string &name) {
+  scancount(data_ptrs, answer, threshold);
+  size_t s1 = answer.size();
+  auto a1 (answer);
+  std::sort(a1.begin(), a1.end());
+  answer.clear();
+  f();
+  size_t s2 = answer.size();
+  auto a2 (answer);
+  std::sort(a2.begin(), a2.end());
+  if (a1 != a2) {
+    std::cout << "s1: " << s1 << " s2: " << s2 << std::endl;
+    for(size_t j = 0; j < std::min(s1, s2); j++) {
+      std::cout << j << " " << a1[j] << " vs " << a2[j] ;
+
+      if(a1[j] != a2[j]) std::cout << " oh oh ";
+      std::cout << std::endl;
+    }
+    throw std::runtime_error("bug: " + name);
   }
 }
 
@@ -87,15 +151,20 @@ void demo_data(const std::vector<std::vector<uint32_t>>& data,
                           };
   LinuxEventsWrapper unified(evts);
 
-  std::vector<const std::vector<uint32_t>*> dataPtrs;
+  std::vector<std::vector<uint32_t>> range_boundaries;
+  calc_alldata_boundaries(data, range_boundaries, range_size_avx512);
 
-  float elapsed = 0, elapsed_fast = 0, elapsed_avx = 0;
+  std::vector<const std::vector<uint32_t>*> data_ptrs;
+  std::vector<const std::vector<uint32_t>*> range_ptrs;
+
+  float elapsed = 0, elapsed_fast = 0, elapsed_avx = 0, elapsed_avx512 = 0;
 
   size_t sum_total = 0;
 
   for (size_t qid = 0; qid < queries.size(); ++qid) {
     const auto& query_elem = queries[qid];
-    dataPtrs.clear();
+    data_ptrs.clear();
+    range_ptrs.clear();
     size_t sum = 0;
     for (uint32_t idx : query_elem) {
       if (idx >= data.size()) {
@@ -105,34 +174,36 @@ void demo_data(const std::vector<std::vector<uint32_t>>& data,
         throw std::runtime_error(err.str());
       }
       sum += data[idx].size();
-      dataPtrs.push_back(&data[idx]);
+      data_ptrs.push_back(&data[idx]);
+      range_ptrs.push_back(&range_boundaries[idx]);
     }
     sum_total += sum;
 
-    scancount(dataPtrs, answer, threshold);
+    scancount(data_ptrs, answer, threshold);
     const size_t expected = answer.size();
-#ifdef __AVX2__
-#define RUNNINGTESTS
-#ifdef RUNNINGTESTS
-    fastscancount::fastscancount(dataPtrs, answer, threshold);
-    size_t s1 = answer.size();
-    auto a1 (answer);
-    std::sort(a1.begin(), a1.end());
-    fastscancount::fastscancount_avx2(dataPtrs, answer, threshold);
-    size_t s2 = answer.size();
-    auto a2 (answer);
-    std::sort(a2.begin(), a2.end());
-    if (a1 != a2) {
-      std::cout << "s1: " << s1 << " s2: " << s2 << std::endl;
-      for(size_t j = 0; j < s1; j++) {
-        std::cout << j << " " << a1[j] << " vs " << a2[j] ;
 
-        if(a1[j] != a2[j]) std::cout << " oh oh ";
-        std::cout << std::endl;
-      }
-      throw new std::runtime_error("bug");
-    }
-#endif 
+#ifdef RUNNINGTESTS
+    test(
+      [&](){
+        fastscancount::fastscancount(data_ptrs, answer, threshold);
+      }, data_ptrs, answer, threshold, "fastscancount"
+    );
+#ifdef __AVX2__
+    test(
+      [&](){
+        fastscancount::fastscancount_avx2(data_ptrs, answer, threshold);
+      }, data_ptrs, answer, threshold, "fastscancount_avx2"
+    );
+#endif
+
+#ifdef __AVX512F__
+    test(
+      [&](){
+        fastscancount::fastscancount_avx512(range_size_avx512, data_ptrs, range_ptrs, answer, threshold);
+      }, data_ptrs, answer, threshold, "fastscancount_avx512"
+    );
+#endif
+
 #endif
     std::cout << "Qid: " << qid << " got " << expected << " hits\n";
 
@@ -140,22 +211,28 @@ void demo_data(const std::vector<std::vector<uint32_t>>& data,
 
     bench(
         [&]() {
-          scancount(dataPtrs, answer, threshold);
+          scancount(data_ptrs, answer, threshold);
         },
         "baseline scancount", unified, elapsed, answer, sum,
         expected, last);
 
     bench(
         [&]() {
-          fastscancount::fastscancount(dataPtrs, answer, threshold);
+          fastscancount::fastscancount(data_ptrs, answer, threshold);
         },
         "optimized cache-sensitive scancount", unified, elapsed_fast, answer, sum,
         expected, last);
-  
+#ifdef __AVX512F__
+    bench(
+        [&]() {
+          fastscancount::fastscancount_avx512(range_size_avx512, data_ptrs, range_ptrs, answer, threshold);
+        },
+        "AVX512-based scancount", unified, elapsed_avx512, answer, sum, expected, last);
+#endif
 #ifdef __AVX2__
     bench(
         [&]() {
-          fastscancount::fastscancount_avx2(dataPtrs, answer, threshold);
+          fastscancount::fastscancount_avx2(data_ptrs, answer, threshold);
         },
         "AVX2-based scancount", unified, elapsed_avx, answer, sum, expected, last);
 #endif
@@ -166,11 +243,17 @@ void demo_data(const std::vector<std::vector<uint32_t>>& data,
 #ifdef __AVX2__
   std::cout << "fastscancount_avx2: " << (sum_total/(elapsed_avx/1e3)) << std::endl; 
 #endif
+#ifdef __AVX512F__
+  std::cout << "fastscancount_avx512: " << (sum_total/(elapsed_avx512/1e3)) << std::endl; 
+#endif
+
 }
+
 
 void demo_random(size_t N, size_t length, size_t array_count, size_t threshold) {
   std::vector<std::vector<uint32_t>> data(array_count);
-  std::vector<const std::vector<uint32_t>*> dataPtrs;
+
+  std::vector<const std::vector<uint32_t>*> data_ptrs;
   std::vector<uint32_t> answer;
   answer.reserve(N);
 
@@ -183,8 +266,17 @@ void demo_random(size_t N, size_t length, size_t array_count, size_t threshold) 
     std::sort(v.begin(), v.end());
     v.resize(std::distance(v.begin(), unique(v.begin(), v.end())));
     sum += v.size();
-    dataPtrs.push_back(&data[c]);
+    data_ptrs.push_back(&data[c]);
   }
+
+
+  std::vector<std::vector<uint32_t>> range_boundaries;
+  calc_alldata_boundaries(data, range_boundaries, range_size_avx512);
+  std::vector<const std::vector<uint32_t>*> range_ptrs;
+  for (size_t c = 0; c < array_count; c++) {
+    range_ptrs.push_back(&range_boundaries[c]);
+  }
+
   std::vector<int> evts = {
 #ifdef __linux__
                            PERF_COUNT_HW_CPU_CYCLES,
@@ -195,44 +287,87 @@ void demo_random(size_t N, size_t length, size_t array_count, size_t threshold) 
 #endif
                           };
   LinuxEventsWrapper unified(evts);
-  float elapsed = 0, elapsed_fast = 0, elapsed_avx = 0;
-  scancount(dataPtrs, answer, threshold);
+  float elapsed = 0, elapsed_fast = 0, elapsed_avx = 0, elapsed_avx512 = 0;
+  scancount(data_ptrs, answer, threshold);
   const size_t expected = answer.size();
   std::cout << "Got " << expected << " hits\n";
-  size_t sum_total = 0;
+  size_t sum_total = sum * REPEATS;
   for (size_t t = 0; t < REPEATS; t++) {
-
-    sum_total += sum;
-
     bool last = (t == REPEATS - 1);
 
     bench(
         [&]() {
-          scancount(dataPtrs, answer, threshold);
+          scancount(data_ptrs, answer, threshold);
         },
         "baseline scancount", unified, elapsed, answer, sum,
         expected, last);
+  }
+
+  for (size_t t = 0; t < REPEATS; t++) {
+    bool last = (t == REPEATS - 1);
+
+#ifdef RUNNINGTESTS
+    test(
+      [&](){
+        fastscancount::fastscancount(data_ptrs, answer, threshold);
+      }, data_ptrs, answer, threshold, "fastscancount"
+    );
+#endif
 
     bench(
         [&]() {
-          fastscancount::fastscancount(dataPtrs, answer, threshold);
+          fastscancount::fastscancount(data_ptrs, answer, threshold);
         },
         "optimized cache-sensitive scancount", unified, elapsed_fast, answer, sum,
         expected, last);
+  }
+
+  for (size_t t = 0; t < REPEATS; t++) {
+    bool last = (t == REPEATS - 1);
 
 #ifdef __AVX2__
+#ifdef RUNNINGTESTS
+    test(
+      [&](){
+        fastscancount::fastscancount_avx2(data_ptrs, answer, threshold);
+      }, data_ptrs, answer, threshold, "fastscancount_avx2"
+    );
+#endif
     bench(
         [&]() {
-          fastscancount::fastscancount_avx2(dataPtrs, answer, threshold);
+          fastscancount::fastscancount_avx2(data_ptrs, answer, threshold);
         },
         "AVX2-based scancount", unified, elapsed_avx, answer, sum, expected, last);
 #endif
   }
+
+  for (size_t t = 0; t < REPEATS; t++) {
+    bool last = (t == REPEATS - 1);
+#ifdef __AVX512F__
+#ifdef RUNNINGTESTS
+    test(
+      [&](){
+        fastscancount::fastscancount_avx512(range_size_avx512, data_ptrs, range_ptrs, answer, threshold);
+      }, data_ptrs, answer, threshold, "fastscancount_avx512"
+    );
+#endif
+
+    bench(
+        [&]() {
+          fastscancount::fastscancount_avx512(range_size_avx512, data_ptrs, range_ptrs, answer, threshold);
+        },
+        "AVX512-based scancount", unified, elapsed_avx512, answer, sum, expected, last);
+#endif
+  }
+
   std::cout << "Elems per millisecond:" << std::endl;
   std::cout << "scancount: " << (sum_total/(elapsed/1e3)) << std::endl; 
   std::cout << "fastscancount: " << (sum_total/(elapsed_fast/1e3)) << std::endl; 
 #ifdef __AVX2__
   std::cout << "fastscancount_avx2: " << (sum_total/(elapsed_avx/1e3)) << std::endl; 
+#endif
+#ifdef __AVX512F__
+  std::cout << "fastscancount_avx512: " << (sum_total/(elapsed_avx512/1e3)) << std::endl; 
 #endif
 }
 
@@ -290,9 +425,25 @@ int main(int argc, char *argv[]) {
       }
     }
               
-    demo_data(data, queries, threshold);
+    try { 
+      demo_data(data, queries, threshold);
+    } catch (const std::exception& e) {
+      std::cerr << "Exception: " << e.what() << std::endl;
+      return EXIT_FAILURE;
+    }
   } else {
-    demo_random(20000000, 50000, 100, 3);
+    try {
+      // Previous demo with threshold 3
+      //demo_random(20000000, 50000, 100, 3);
+      for (unsigned k = 1; k < 10; ++k) {
+        std::cout << "Demo threshold:" << k << std::endl;
+        demo_random(20000000, 50000, 100, k);
+        std::cout << "=======================" << std::endl;
+      }
+    } catch (const std::exception& e) {
+      std::cerr << "Exception: " << e.what() << std::endl;
+      return EXIT_FAILURE;
+    }
   }
   return EXIT_SUCCESS;
 }

--- a/benchmark/counters.cpp
+++ b/benchmark/counters.cpp
@@ -222,19 +222,19 @@ void demo_data(const std::vector<std::vector<uint32_t>>& data,
         },
         "optimized cache-sensitive scancount", unified, elapsed_fast, answer, sum,
         expected, last);
-#ifdef __AVX512F__
-    bench(
-        [&]() {
-          fastscancount::fastscancount_avx512(range_size_avx512, data_ptrs, range_ptrs, answer, threshold);
-        },
-        "AVX512-based scancount", unified, elapsed_avx512, answer, sum, expected, last);
-#endif
 #ifdef __AVX2__
     bench(
         [&]() {
           fastscancount::fastscancount_avx2(data_ptrs, answer, threshold);
         },
         "AVX2-based scancount", unified, elapsed_avx, answer, sum, expected, last);
+#endif
+#ifdef __AVX512F__
+    bench(
+        [&]() {
+          fastscancount::fastscancount_avx512(range_size_avx512, data_ptrs, range_ptrs, answer, threshold);
+        },
+        "AVX512-based scancount", unified, elapsed_avx512, answer, sum, expected, last);
 #endif
   }
   std::cout << "Elems per millisecond:" << std::endl;

--- a/include/fastscancount_avx2.h
+++ b/include/fastscancount_avx2.h
@@ -124,7 +124,6 @@ void fastscancount_avx2(const std::vector<const std::vector<uint32_t>*> &data,
     }
 
     populate_hits_avx(counters, cache_size, threshold, start, out);
-    //add_populate_hits_avx512(counters, cache_size, threshold, start, out);
   }
 }
 

--- a/include/fastscancount_avx2.h
+++ b/include/fastscancount_avx2.h
@@ -78,6 +78,35 @@ void update_counters_final(const uint32_t *&it_, const uint32_t *end,
   }
   it_ = end;
 }
+void add_populate_hits_avx512(std::vector<uint8_t> &counters, size_t range,
+                       size_t threshold, size_t start,
+                       std::vector<uint32_t> &out) {
+  uint8_t *array = counters.data();
+
+  size_t vsize = range / 64;
+  __m512i *varray = (__m512i *)array;
+  const __m512i comprand = _mm512_set1_epi8(threshold);
+
+  for (size_t i = 0; i < vsize; i++) {
+    size_t start_add = start + i*64;
+    __m512i v = _mm512_loadu_si512(varray + i);
+    uint64_t bits = _mm512_cmpgt_epi8_mask(v, comprand);
+    while (bits) {
+      unsigned zqty = __builtin_ctzll(bits);
+      bits >>= zqty; 
+      bits >>= 1; // If zqty = 63, shift by 64 is not defined, need to split shifts
+      out.push_back(start_add + zqty);
+      start_add += zqty + 1;
+    }
+  }
+
+  for (size_t i = vsize * 64; i < range; i++) {
+    auto v = array[i];
+    if (v > threshold)
+      out.push_back(start + i);
+  }
+
+}
 } // namespace
 
 void fastscancount_avx2(const std::vector<const std::vector<uint32_t>*> &data,
@@ -124,6 +153,7 @@ void fastscancount_avx2(const std::vector<const std::vector<uint32_t>*> &data,
     }
 
     populate_hits_avx(counters, cache_size, threshold, start, out);
+    //add_populate_hits_avx512(counters, cache_size, threshold, start, out);
   }
 }
 

--- a/include/fastscancount_avx512.h
+++ b/include/fastscancount_avx512.h
@@ -68,7 +68,7 @@ void update_counters_avx512(const uint32_t  *&it_, const uint32_t  *end,
 
   for (unsigned i = 0; i < vsize; ++i) {
     __m512i indx = _mm512_sub_epi32(_mm512_loadu_si512(varray + i), shift_vect);
-    __m512i v_orig = _mm512_i32gather_epi32(indx, counters, 1);
+    __m512i v_orig = _mm512_i32gather_epi32(indx, (const int*)counters, 1);
     // Note: works correctly only if counters never overflow
     // First, we increment counters.
     __m512i v_inc = _mm512_add_epi32(v_orig, add1);
@@ -76,7 +76,7 @@ void update_counters_avx512(const uint32_t  *&it_, const uint32_t  *end,
     // When 32-bit words overlap, the gather operation would first write the old values of the word
     // then it will overwrite them with new values. So, this should work just fine.
     __m512i v = _mm512_mask_blend_epi8(blend_mask, v_orig, v_inc);
-    _mm512_i32scatter_epi32(counters, indx, v, 1);
+    _mm512_i32scatter_epi32((int*)counters, indx, v, 1);
   }
 
   // tail processing

--- a/include/fastscancount_avx512.h
+++ b/include/fastscancount_avx512.h
@@ -1,0 +1,138 @@
+#ifndef FASTSCANCOUNT_AVX512_H
+#define FASTSCANCOUNT_AVX512_H
+
+// this code expects an x64 processor with AVX-512F
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#else
+#include <x86intrin.h>
+#endif
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+#include <stdexcept>
+
+namespace fastscancount {
+namespace {
+
+// credit: inspired by 256-bit implementation of Travis Downes
+void populate_hits_avx512(std::vector<uint8_t> &counters, size_t range,
+                       size_t threshold, size_t start,
+                       std::vector<uint32_t> &out) {
+  uint8_t *array = counters.data();
+
+  size_t vsize = range / 64;
+  __m512i *varray = (__m512i *)array;
+  const __m512i comprand = _mm512_set1_epi8(threshold);
+
+  for (size_t i = 0; i < vsize; i++) {
+    size_t start_add = start + i*64;
+    __m512i v = _mm512_loadu_si512(varray + i);
+    uint64_t bits = _mm512_cmpgt_epi8_mask(v, comprand);
+    while (bits) {
+      unsigned zqty = __builtin_ctzll(bits);
+      bits >>= zqty; 
+      bits >>= 1; // If zqty = 63, shift by 64 is not defined, need to split shifts
+      out.push_back(start_add + zqty);
+      start_add += zqty + 1;
+    }
+  }
+
+  for (size_t i = vsize * 64; i < range; i++) {
+    auto v = array[i];
+    if (v > threshold)
+      out.push_back(start + i);
+  }
+
+}
+
+void update_counters_avx512(const uint32_t  *&it_, const uint32_t  *end,
+                            uint8_t *counters, 
+                            const size_t shift) {
+
+  if (it_ > end) {
+    throw std::runtime_error("Bug: start > end");
+  }
+  size_t qty = end - it_;
+  size_t vsize = qty / 16;
+
+  __m512i *varray = (__m512i *)it_;
+  const __m512i add1 = _mm512_set1_epi32(1);
+  const __m512i shift_vect = _mm512_set1_epi32(shift);
+
+  const __mmask64 blend_mask = 0x1111111111111111ull;
+
+  for (unsigned i = 0; i < vsize; ++i) {
+    __m512i indx = _mm512_sub_epi32(_mm512_loadu_si512(varray + i), shift_vect);
+    __m512i v_orig = _mm512_i32gather_epi32(indx, counters, 1);
+    // Note: works correctly only if counters never overflow
+    // First, we increment counters.
+    __m512i v_inc = _mm512_add_epi32(v_orig, add1);
+    // Then, we will blend by keeping three higher-order bytes in each 32-bit word unmodified
+    // When 32-bit words overlap, the gather operation would first write the old values of the word
+    // then it will overwrite them with new values. So, this should work just fine.
+    __m512i v = _mm512_mask_blend_epi8(blend_mask, v_orig, v_inc);
+    _mm512_i32scatter_epi32(counters, indx, v, 1);
+  }
+
+  // tail processing
+  const uint32_t  *it = it_ + vsize * 16;
+  for (; it != end; it++) {
+    counters[*it-shift]++;
+  }
+  it_ = end;
+}
+
+
+} // namespace
+
+void fastscancount_avx512(uint32_t cache_size,
+                          const std::vector<const std::vector<uint32_t>*> &data,
+                          const std::vector<const std::vector<uint32_t>*> &range_ends,
+                          std::vector<uint32_t> &out, uint8_t threshold) {
+  std::vector<uint8_t> counters(cache_size);
+  out.clear();
+  const size_t dsize = data.size();
+  if (!dsize) {
+    return;
+  }
+  if (dsize != range_ends.size()) {
+    throw std::runtime_error("Invalid input: non-matching sizes between data and range_ends");
+  }
+
+  unsigned range_qty = range_ends[0]->size();
+  for (unsigned i = 1; i < dsize; ++i) {
+    if (range_ends[i]->size() != range_qty) {
+      throw std::runtime_error("Invalid input: different range sizes for different data arrays!");
+    }
+  }
+
+  auto cdata = counters.data();
+
+  std::vector<const uint32_t*> it(dsize);
+  for (unsigned k = 0; k < dsize; ++k) {
+    const auto& v = *data[k];  
+    if (!v.empty()) {
+      it[k] = &v[0];
+    }
+  }
+
+  for (unsigned i = 0; i < range_qty; ++i) {
+    memset(cdata, 0, cache_size * sizeof(counters[0]));
+    uint32_t start = i * cache_size;
+    for (unsigned k = 0; k < dsize; ++k) {
+      const std::vector<uint32_t>& v = *data[k];
+      const std::vector<uint32_t>& r = *range_ends[k];
+      update_counters_avx512(it[k], &v[0] + r[i], cdata, start);
+    }
+
+    populate_hits_avx512(counters, cache_size, threshold, start, out);
+  }
+}
+
+} // namespace fastscancount
+#endif


### PR DESCRIPTION
1. Adding mostly 512-bit test (requires explicit boundary precomputation)
2. Fixing one eval bug where the counter wasn't set to zero
3. Re-factoring & expanding correctness check 